### PR TITLE
Add trope-mode

### DIFF
--- a/recipes/trope-mode
+++ b/recipes/trope-mode
@@ -1,0 +1,1 @@
+(trope-mode :fetcher github :repo "TriAttack238/trope-mode")


### PR DESCRIPTION
Add the recepie for Trope-Mode, a Emacs major mode for the TV Tropes markup syntax.

### Brief summary of what the package does

[TV Tropes](https://tvtropes.org/) is a wiki and forum for media and the tropes relating to it. 

### Direct link to the package repository

https://github.com/TriAttack238/trope-mode

### Your association with the package

I am the package author and its sole maintainer.

### Relevant communications with the upstream package maintainer

**None Needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] I've used `M-x checkdoc` to check the package's documentation strings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
